### PR TITLE
Turtle 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
-## Turtle 0.1.2:
+## Turtle 0.1.3
+
+* Fixing `Get-Turtle` inline sets (#108, #107)
+* Fixing `.PNG/JPEG/WEBP` to no longer try to use msedge (#110)
+* Adding `Turtle.get/set_FillRule` to get or set the fill rule for the turtle. (#109)
+
+---
+
+## Turtle 0.1.2
 
 * `Get-Turtle/Turtle` can now get or set properties or methods
 * New Methods:
@@ -9,7 +17,9 @@
   * `Turtle.Save()` calls Save-Turtle
 * Explicitly exporting commands from module
 
-## Turtle 0.1.1:
+---
+
+## Turtle 0.1.1
 
 * Updates:
   * `Turtle.get/set_ID` allows for turtle identifiers
@@ -28,7 +38,7 @@
 
 ---
 
-## Turtle 0.1:
+## Turtle 0.1
 
 * Initial Release
 * Builds a Turtle Graphics engine in PowerShell

--- a/Commands/Get-Turtle.ps1
+++ b/Commands/Get-Turtle.ps1
@@ -165,19 +165,19 @@ function Get-Turtle {
                 }
 
             # If the output is not a turtle object, we can output it.
-            # NOTE: This will lead to multiple types of output in the pipeline.
+            # NOTE: This may lead to multiple types of output in the pipeline.
             # Luckily, this should be one of the few cases where this does not annoy too much.
-            # Properties being returned will largely be strings or numbers.
-            if (-not ($stepOutput.pstypenames -eq 'Turtle')) {
+            # Properties being returned will largely be strings or numbers, and these will always output directly.
+            if ($null -ne $stepOutput -and -not ($stepOutput.pstypenames -eq 'Turtle')) {
                 # Output the step
                 $stepOutput 
                 # and set the output turtle to false.
                 $outputTurtle = $false                
-            } else {
+            } elseif ($null -ne $stepOutput) {
                 # Set the current turtle to the step output.
                 $currentTurtle = $stepOutput
                 # and output it later (presumably).
-                $outputTurtle = $true                
+                $outputTurtle = $true
             }
         }
 

--- a/Turtle.psd1
+++ b/Turtle.psd1
@@ -1,6 +1,6 @@
 @{    
     # Version number of this module.
-    ModuleVersion = '0.1.2'
+    ModuleVersion = '0.1.3'
     # Description of the module
     Description = "Turtles in a PowerShell"
     # Script module or binary module file associated with this manifest.
@@ -37,7 +37,15 @@
             # A URL to the license for this module.
             LicenseURI = 'https://github.com/PowerShellWeb/Turtle/blob/main/LICENSE'
             ReleaseNotes = @'
-## Turtle 0.1.2:
+## Turtle 0.1.3
+
+* Fixing `Get-Turtle` inline sets (#108, #107)
+* Fixing `.PNG/JPEG/WEBP` to no longer try to use msedge (#110)
+* Adding `Turtle.get/set_FillRule` to get or set the fill rule for the turtle. (#109)
+
+---
+
+## Turtle 0.1.2
 
 * `Get-Turtle/Turtle` can now get or set properties or methods
 * New Methods:
@@ -48,7 +56,9 @@
   * `Turtle.Save()` calls Save-Turtle
 * Explicitly exporting commands from module
 
-## Turtle 0.1.1:
+---
+
+## Turtle 0.1.1
 
 * Updates:
   * `Turtle.get/set_ID` allows for turtle identifiers
@@ -67,7 +77,7 @@
 
 ---
 
-## Turtle 0.1:
+## Turtle 0.1
 
 * Initial Release
 * Builds a Turtle Graphics engine in PowerShell

--- a/Turtle.types.ps1xml
+++ b/Turtle.types.ps1xml
@@ -1570,7 +1570,7 @@ if ($VerbosePreference -ne 'SilentlyContinue') {
       <ScriptProperty>
         <Name>JPEG</Name>
         <GetScriptBlock>
-                        $chromiumNames = 'chromium','chrome','msedge'
+                        $chromiumNames = 'chromium','chrome'
 foreach ($browserName in $chromiumNames) {
     $chromiumCommand = 
         $ExecutionContext.SessionState.InvokeCommand.GetCommand($browserName,'Application')
@@ -1881,7 +1881,7 @@ $this | Add-Member -MemberType NoteProperty -Force -Name '.PatternTransform' -Va
       <ScriptProperty>
         <Name>PNG</Name>
         <GetScriptBlock>
-                        $chromiumNames = 'chromium','chrome','msedge'
+                        $chromiumNames = 'chromium','chrome'
 foreach ($browserName in $chromiumNames) {
     $chromiumCommand = 
         $ExecutionContext.SessionState.InvokeCommand.GetCommand($browserName,'Application')
@@ -2136,7 +2136,7 @@ $this | Add-Member -MemberType NoteProperty -Force -Name '.ViewBox' -Value $view
       <ScriptProperty>
         <Name>WEBP</Name>
         <GetScriptBlock>
-                        $chromiumNames = 'chromium','chrome','msedge'
+                        $chromiumNames = 'chromium','chrome'
 foreach ($browserName in $chromiumNames) {
     $chromiumCommand = 
         $ExecutionContext.SessionState.InvokeCommand.GetCommand($browserName,'Application')

--- a/Types/Turtle/get_FillRule.ps1
+++ b/Types/Turtle/get_FillRule.ps1
@@ -1,0 +1,8 @@
+if (-not $this.'.PathAttribute') {
+    $this | Add-Member -MemberType NoteProperty -Name '.PathAttribute' -Value ([Ordered]@{}) -Force
+}
+if ($this.'.PathAttribute'.'fill-rule') {
+    return $this.'.PathAttribute'.'fill-rule'
+} else {
+    'nonzero'
+}

--- a/Types/Turtle/get_JPEG.ps1
+++ b/Types/Turtle/get_JPEG.ps1
@@ -1,4 +1,4 @@
-$chromiumNames = 'chromium','chrome','msedge'
+$chromiumNames = 'chromium','chrome'
 foreach ($browserName in $chromiumNames) {
     $chromiumCommand = 
         $ExecutionContext.SessionState.InvokeCommand.GetCommand($browserName,'Application')

--- a/Types/Turtle/get_PNG.ps1
+++ b/Types/Turtle/get_PNG.ps1
@@ -1,4 +1,4 @@
-$chromiumNames = 'chromium','chrome','msedge'
+$chromiumNames = 'chromium','chrome'
 foreach ($browserName in $chromiumNames) {
     $chromiumCommand = 
         $ExecutionContext.SessionState.InvokeCommand.GetCommand($browserName,'Application')

--- a/Types/Turtle/get_WEBP.ps1
+++ b/Types/Turtle/get_WEBP.ps1
@@ -1,4 +1,4 @@
-$chromiumNames = 'chromium','chrome','msedge'
+$chromiumNames = 'chromium','chrome'
 foreach ($browserName in $chromiumNames) {
     $chromiumCommand = 
         $ExecutionContext.SessionState.InvokeCommand.GetCommand($browserName,'Application')

--- a/Types/Turtle/set_FillRule.ps1
+++ b/Types/Turtle/set_FillRule.ps1
@@ -1,0 +1,6 @@
+param(
+[ValidateSet('nonzero', 'evenodd')]
+[string]
+$fillRule = 'nonzero'
+)
+$this.PathAttribute = [Ordered]@{'fill-rule' = $fillRule.ToLower()}


### PR DESCRIPTION
## Turtle 0.1.3:

* Fixing `Get-Turtle` inline sets (#108, #107)
* Fixing `.PNG/JPEG/WEBP` to no longer try to use msedge (#110)
* Adding `Turtle.get/set_FillRule` to get or set the fill rule for the turtle. (#109)

---